### PR TITLE
Solves DS_STORE problem on MAC

### DIFF
--- a/DocumentScanner.py
+++ b/DocumentScanner.py
@@ -44,7 +44,7 @@ while ret:
         break
             
 cv2.destroyAllWindows()
-imagelist = os.listdir("E://pdf")
+imagelist = [f for f in os.listdir('E://pdf') if os.path.isfile(f)]
 pdf = FPDF()
 for image in imagelist:
     image = "E://pdf//"+image


### PR DESCRIPTION
In MAC OS there is a hidden file called .DS_STORE which interrupts the program and doesn't let the pdf file created.